### PR TITLE
Add storage challenge submission and tracking UI

### DIFF
--- a/frontend/src/app/challenges/[id]/page.tsx
+++ b/frontend/src/app/challenges/[id]/page.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { use } from 'react';
+import { useFetchChallenges } from '@/hooks/useFetchChallenges';
+import { useRespondToChallenge } from '@/hooks/useRespondToChallenge';
+import ChallengeTimeline from '@/components/ChallengeTimeline';
+import ChallengeStatusBadge from '@/components/ChallengeStatusBadge';
+import ChallengeResponseForm from '@/components/ChallengeResponseForm';
+import { formatDeadline, getBlocksUntilDeadline } from '@/lib/challengeUtils';
+
+const CURRENT_BLOCK = 144900;
+const CONNECTED_ADDRESS = ''; // hook into wallet context in production
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+function truncate(str: string) {
+  return `${str.slice(0, 8)}...${str.slice(-6)}`;
+}
+
+export default function ChallengeDetailPage({ params }: PageProps) {
+  const { id } = use(params);
+  const { challenges, loading } = useFetchChallenges();
+  const { responding, error: respondError, txId, respond } = useRespondToChallenge();
+
+  const challenge = challenges.find((c) => c.id === id);
+
+  if (loading) {
+    return (
+      <main className="mx-auto max-w-3xl px-4 py-10">
+        <div className="animate-pulse space-y-4">
+          <div className="h-8 w-56 rounded bg-gray-200" />
+          <div className="h-24 rounded-xl bg-gray-100" />
+        </div>
+      </main>
+    );
+  }
+
+  if (!challenge) {
+    return (
+      <main className="mx-auto max-w-3xl px-4 py-10">
+        <p className="text-gray-500">Challenge &quot;{id}&quot; not found.</p>
+      </main>
+    );
+  }
+
+  const blocksLeft = getBlocksUntilDeadline(challenge, CURRENT_BLOCK);
+  const canRespond = challenge.status === 'pending' && blocksLeft > 0;
+
+  return (
+    <main className="mx-auto max-w-3xl px-4 py-10 space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-bold text-gray-900 font-mono">{challenge.id}</h1>
+          <p className="text-sm text-gray-400 mt-0.5">Commitment #{challenge.commitmentId}</p>
+        </div>
+        <ChallengeStatusBadge status={challenge.status} />
+      </div>
+
+      <ChallengeTimeline status={challenge.status} />
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="rounded-xl border border-gray-200 bg-white p-4">
+          <p className="text-xs text-gray-500">Challenger</p>
+          <p className="font-mono text-sm mt-1">{truncate(challenge.challenger)}</p>
+        </div>
+        <div className="rounded-xl border border-gray-200 bg-white p-4">
+          <p className="text-xs text-gray-500">Provider</p>
+          <p className="font-semibold text-sm mt-1">#{challenge.providerId}</p>
+        </div>
+        <div className="rounded-xl border border-gray-200 bg-white p-4">
+          <p className="text-xs text-gray-500">Challenge Block</p>
+          <p className="font-semibold text-sm mt-1">#{challenge.challengeBlock}</p>
+        </div>
+        <div className="rounded-xl border border-gray-200 bg-white p-4">
+          <p className="text-xs text-gray-500">Deadline Block</p>
+          <p className="font-semibold text-sm mt-1">
+            #{challenge.responseDeadlineBlock}
+            {challenge.status === 'pending' && (
+              <span className="ml-1 text-xs text-yellow-600">({formatDeadline(blocksLeft)} left)</span>
+            )}
+          </p>
+        </div>
+      </div>
+
+      {challenge.status === 'slashed' && challenge.slashAmount !== undefined && (
+        <div className="rounded-xl border border-red-200 bg-red-50 p-4">
+          <p className="text-sm font-semibold text-red-700">Slash Executed</p>
+          <p className="text-sm text-red-600 mt-1">
+            {(challenge.slashAmount / 1_000_000).toFixed(6)} STX slashed due to failed challenge response.
+          </p>
+        </div>
+      )}
+
+      {challenge.responseHash && (
+        <div className="rounded-xl border border-green-200 bg-green-50 p-4">
+          <p className="text-sm font-semibold text-green-700">Response Submitted</p>
+          <p className="font-mono text-xs text-green-800 mt-1 break-all">{challenge.responseHash}</p>
+        </div>
+      )}
+
+      {canRespond && (
+        <ChallengeResponseForm
+          challengeId={challenge.id}
+          onSubmit={(hash, proof) => respond(challenge.id, hash, proof)}
+          responding={responding}
+          error={respondError}
+          txId={txId}
+        />
+      )}
+    </main>
+  );
+}

--- a/frontend/src/app/challenges/page.tsx
+++ b/frontend/src/app/challenges/page.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useState } from 'react';
+import { useFetchChallenges } from '@/hooks/useFetchChallenges';
+import ChallengeCard from '@/components/ChallengeCard';
+import type { ChallengeStatus } from '@/types/challenge';
+
+const ACTIVE_STATUSES: ChallengeStatus[] = ['pending', 'responded'];
+const RESOLVED_STATUSES: ChallengeStatus[] = ['validated', 'slashed', 'expired'];
+
+export default function ChallengesPage() {
+  const { challenges, loading, error, filterByStatus } = useFetchChallenges();
+  const [tab, setTab] = useState<'active' | 'resolved'>('active');
+
+  const activeChallenges = challenges.filter((c) => ACTIVE_STATUSES.includes(c.status));
+  const resolvedChallenges = challenges.filter((c) => RESOLVED_STATUSES.includes(c.status));
+
+  const displayed = tab === 'active' ? activeChallenges : resolvedChallenges;
+
+  const slashedList = filterByStatus('slashed');
+  const totalSlash = slashedList.reduce((sum, c) => sum + (c.slashAmount ?? 0), 0);
+  const totalResolved = resolvedChallenges.length;
+  const responseRate =
+    challenges.length > 0
+      ? Math.round((challenges.filter((c) => c.responseHash).length / challenges.length) * 100)
+      : 0;
+
+  return (
+    <main className="mx-auto max-w-4xl px-4 py-10 space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Challenges</h1>
+        <p className="text-sm text-gray-500 mt-1">Storage challenge submissions and their outcomes.</p>
+      </div>
+
+      <div className="grid grid-cols-3 gap-4">
+        <div className="rounded-xl border border-gray-200 bg-white p-4 text-center">
+          <p className="text-2xl font-bold text-yellow-600">{activeChallenges.length}</p>
+          <p className="text-xs text-gray-500 mt-1">Open Challenges</p>
+        </div>
+        <div className="rounded-xl border border-gray-200 bg-white p-4 text-center">
+          <p className="text-2xl font-bold text-red-600">{(totalSlash / 1_000_000).toFixed(2)}</p>
+          <p className="text-xs text-gray-500 mt-1">Total Slashed (STX)</p>
+        </div>
+        <div className="rounded-xl border border-gray-200 bg-white p-4 text-center">
+          <p className="text-2xl font-bold text-green-600">{responseRate}%</p>
+          <p className="text-xs text-gray-500 mt-1">Response Rate</p>
+        </div>
+      </div>
+
+      <div className="flex gap-1 border-b border-gray-200">
+        {(['active', 'resolved'] as const).map((t) => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`px-4 py-2 text-sm font-medium capitalize transition-colors border-b-2 -mb-px ${
+              tab === t
+                ? 'border-primary-600 text-primary-700'
+                : 'border-transparent text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            {t} ({t === 'active' ? activeChallenges.length : resolvedChallenges.length})
+          </button>
+        ))}
+      </div>
+
+      {loading && (
+        <div className="space-y-3">
+          {[1, 2].map((n) => (
+            <div key={n} className="animate-pulse h-32 rounded-xl bg-gray-100" />
+          ))}
+        </div>
+      )}
+
+      {error && (
+        <p className="text-sm text-red-500">{error}</p>
+      )}
+
+      {!loading && displayed.length === 0 && (
+        <p className="text-sm text-gray-400 py-8 text-center">No {tab} challenges.</p>
+      )}
+
+      <div className="space-y-3">
+        {displayed.map((challenge) => (
+          <ChallengeCard key={challenge.id} challenge={challenge} />
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -36,6 +36,26 @@
   }
 }
 
+/* Challenge protocol styles */
+.challenge-card {
+  border-left: 4px solid #f59e0b;
+}
+.challenge-card--slashed {
+  border-left-color: #dc2626;
+}
+.challenge-timeline-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid currentColor;
+  flex-shrink: 0;
+}
+.challenge-timeline-line {
+  width: 2px;
+  background: #e5e7eb;
+  flex: 1;
+}
+
 body {
   color: rgb(var(--foreground-rgb));
   background: linear-gradient(

--- a/frontend/src/components/ChallengeCard.tsx
+++ b/frontend/src/components/ChallengeCard.tsx
@@ -15,13 +15,16 @@ const CURRENT_BLOCK = 144900; // TODO: replace with live block from Stacks API
 interface ChallengeCardProps {
   challenge: Challenge;
   onRespond?: (id: string) => void;
+  merkleRoot?: string;
+  chunkCount?: number;
+  storageSizeMb?: number;
 }
 
 function truncate(str: string, start = 6, end = 4): string {
   return `${str.slice(0, start)}...${str.slice(-end)}`;
 }
 
-export default function ChallengeCard({ challenge, onRespond }: ChallengeCardProps) {
+export default function ChallengeCard({ challenge, onRespond, merkleRoot, chunkCount, storageSizeMb }: ChallengeCardProps) {
   const [expanded, setExpanded] = useState(false);
   const blocksLeft = getBlocksUntilDeadline(challenge, CURRENT_BLOCK);
   const progress = getResponseWindowProgress(challenge, CURRENT_BLOCK);
@@ -102,6 +105,13 @@ export default function ChallengeCard({ challenge, onRespond }: ChallengeCardPro
           <p>Challenge block: #{challenge.challengeBlock}</p>
           <p>Deadline block: #{challenge.responseDeadlineBlock}</p>
           <p>Provider: #{challenge.providerId}</p>
+          {merkleRoot && (
+            <p className="font-mono text-xs text-gray-500 break-all">Merkle root: {merkleRoot.slice(0, 16)}…{merkleRoot.slice(-8)}</p>
+          )}
+          {chunkCount !== undefined && <p>Chunks: {chunkCount}</p>}
+          {storageSizeMb !== undefined && (
+            <p>Storage: {storageSizeMb >= 1024 ? `${(storageSizeMb / 1024).toFixed(1)} GB` : `${storageSizeMb} MB`}</p>
+          )}
           {challenge.slashAmount !== undefined && (
             <p className="text-red-600 font-medium">
               Slash: {(challenge.slashAmount / 1_000_000).toFixed(6)} STX

--- a/frontend/src/components/ChallengeCard.tsx
+++ b/frontend/src/components/ChallengeCard.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { useState } from 'react';
+import type { Challenge } from '@/types/challenge';
+import {
+  getBlocksUntilDeadline,
+  formatDeadline,
+  getChallengeStatusColor,
+  getResponseWindowProgress,
+} from '@/lib/challengeUtils';
+import ChallengeStatusBadge from './ChallengeStatusBadge';
+
+const CURRENT_BLOCK = 144900; // TODO: replace with live block from Stacks API
+
+interface ChallengeCardProps {
+  challenge: Challenge;
+  onRespond?: (id: string) => void;
+}
+
+function truncate(str: string, start = 6, end = 4): string {
+  return `${str.slice(0, start)}...${str.slice(-end)}`;
+}
+
+export default function ChallengeCard({ challenge, onRespond }: ChallengeCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const blocksLeft = getBlocksUntilDeadline(challenge, CURRENT_BLOCK);
+  const progress = getResponseWindowProgress(challenge, CURRENT_BLOCK);
+
+  const actionButton = () => {
+    if (challenge.status === 'pending') {
+      return (
+        <button
+          onClick={() => onRespond?.(challenge.id)}
+          className="rounded-lg bg-yellow-500 px-3 py-1.5 text-xs font-medium text-white hover:bg-yellow-600"
+        >
+          Respond
+        </button>
+      );
+    }
+    if (challenge.status === 'responded') {
+      return (
+        <button className="rounded-lg bg-blue-100 px-3 py-1.5 text-xs font-medium text-blue-700">
+          View Response
+        </button>
+      );
+    }
+    return (
+      <span className="text-xs text-gray-400">
+        {challenge.status === 'expired' ? 'Expired' : challenge.status}
+      </span>
+    );
+  };
+
+  return (
+    <div className="challenge-card rounded-xl bg-white p-5 shadow-sm">
+      <div className="flex items-start justify-between mb-3">
+        <div>
+          <div className="flex items-center gap-2 mb-1">
+            <ChallengeStatusBadge status={challenge.status} />
+            <button
+              onClick={() => {
+                navigator.clipboard.writeText(challenge.id);
+              }}
+              className="text-xs text-gray-400 hover:text-gray-600"
+              title="Copy challenge ID"
+            >
+              {truncate(challenge.id, 8, 4)} ⧉
+            </button>
+          </div>
+          <p className="text-xs text-gray-500">Commitment #{challenge.commitmentId}</p>
+          <p className="text-xs text-gray-400">Challenger: {truncate(challenge.challenger)}</p>
+        </div>
+        {actionButton()}
+      </div>
+
+      {challenge.status === 'pending' && (
+        <div className="mt-3">
+          <div className="flex justify-between text-xs text-gray-500 mb-1">
+            <span>Response window</span>
+            <span className={getChallengeStatusColor(challenge.status)}>
+              {formatDeadline(blocksLeft)} remaining
+            </span>
+          </div>
+          <div className="h-2 rounded-full bg-gray-100 overflow-hidden">
+            <div
+              className={`h-full transition-all ${progress >= 80 ? 'bg-red-400' : 'bg-yellow-400'}`}
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        </div>
+      )}
+
+      <button
+        onClick={() => setExpanded((v) => !v)}
+        className="mt-3 text-xs text-gray-400 hover:text-gray-600"
+      >
+        {expanded ? 'Hide details ▲' : 'Show details ▼'}
+      </button>
+
+      {expanded && (
+        <div className="mt-3 space-y-1 text-xs text-gray-600 border-t border-gray-100 pt-3">
+          <p>Challenge block: #{challenge.challengeBlock}</p>
+          <p>Deadline block: #{challenge.responseDeadlineBlock}</p>
+          <p>Provider: #{challenge.providerId}</p>
+          {challenge.slashAmount !== undefined && (
+            <p className="text-red-600 font-medium">
+              Slash: {(challenge.slashAmount / 1_000_000).toFixed(6)} STX
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ChallengeResponseForm.tsx
+++ b/frontend/src/components/ChallengeResponseForm.tsx
@@ -26,6 +26,7 @@ export default function ChallengeResponseForm({
   const [proofLines, setProofLines] = useState('');
   const [showHelp, setShowHelp] = useState(false);
   const [draftRestored, setDraftRestored] = useState(false);
+  const [draftSavedAt, setDraftSavedAt] = useState<string | null>(null);
   const [successToast, setSuccessToast] = useState(false);
 
   useEffect(() => {
@@ -45,7 +46,9 @@ export default function ChallengeResponseForm({
 
   useEffect(() => {
     if (responseHash || proofLines) {
-      localStorage.setItem(DRAFT_KEY(challengeId), JSON.stringify({ hash: responseHash, proof: proofLines }));
+      const savedAt = new Date().toLocaleTimeString();
+      localStorage.setItem(DRAFT_KEY(challengeId), JSON.stringify({ hash: responseHash, proof: proofLines, savedAt }));
+      setDraftSavedAt(savedAt);
     }
   }, [challengeId, responseHash, proofLines]);
 
@@ -77,6 +80,9 @@ export default function ChallengeResponseForm({
         <h3 className="text-sm font-semibold text-gray-900">Submit Challenge Response</h3>
         {draftRestored && (
           <span className="text-xs text-blue-600 bg-blue-50 px-2 py-0.5 rounded-full">Draft restored</span>
+        )}
+        {draftSavedAt && !draftRestored && (
+          <span className="text-xs text-gray-400">Draft saved {draftSavedAt}</span>
         )}
         {successToast && (
           <span className="text-xs text-green-600 bg-green-50 px-2 py-0.5 rounded-full">Response submitted!</span>

--- a/frontend/src/components/ChallengeResponseForm.tsx
+++ b/frontend/src/components/ChallengeResponseForm.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import MerkleProofInput from './MerkleProofInput';
+import { validateMerkleProof } from '@/lib/challengeUtils';
+
+interface ChallengeResponseFormProps {
+  challengeId: string;
+  onSubmit: (responseHash: string, merkleProof: string[]) => Promise<void>;
+  responding?: boolean;
+  error?: string | null;
+  txId?: string | null;
+}
+
+const HEX64_PATTERN = /^[0-9a-fA-F]{64}$/;
+const DRAFT_KEY = (id: string) => `challenge_draft_${id}`;
+
+export default function ChallengeResponseForm({
+  challengeId,
+  onSubmit,
+  responding = false,
+  error = null,
+  txId = null,
+}: ChallengeResponseFormProps) {
+  const [responseHash, setResponseHash] = useState('');
+  const [proofLines, setProofLines] = useState('');
+  const [showHelp, setShowHelp] = useState(false);
+  const [draftRestored, setDraftRestored] = useState(false);
+  const [successToast, setSuccessToast] = useState(false);
+
+  useEffect(() => {
+    const saved = localStorage.getItem(DRAFT_KEY(challengeId));
+    if (saved) {
+      try {
+        const { hash, proof } = JSON.parse(saved);
+        setResponseHash(hash ?? '');
+        setProofLines(proof ?? '');
+        setDraftRestored(true);
+        setTimeout(() => setDraftRestored(false), 3000);
+      } catch {
+        // ignore
+      }
+    }
+  }, [challengeId]);
+
+  useEffect(() => {
+    if (responseHash || proofLines) {
+      localStorage.setItem(DRAFT_KEY(challengeId), JSON.stringify({ hash: responseHash, proof: proofLines }));
+    }
+  }, [challengeId, responseHash, proofLines]);
+
+  useEffect(() => {
+    if (txId) {
+      setSuccessToast(true);
+      localStorage.removeItem(DRAFT_KEY(challengeId));
+    }
+  }, [txId, challengeId]);
+
+  const merkleProof = proofLines
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+
+  const { valid: proofValid, errors: proofErrors } = validateMerkleProof(merkleProof);
+  const hashValid = HEX64_PATTERN.test(responseHash);
+  const canSubmit = hashValid && proofValid && !responding && !txId;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+    await onSubmit(responseHash, merkleProof);
+  };
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-gray-900">Submit Challenge Response</h3>
+        {draftRestored && (
+          <span className="text-xs text-blue-600 bg-blue-50 px-2 py-0.5 rounded-full">Draft restored</span>
+        )}
+        {successToast && (
+          <span className="text-xs text-green-600 bg-green-50 px-2 py-0.5 rounded-full">Response submitted!</span>
+        )}
+      </div>
+
+      {txId && (
+        <div className="rounded-lg bg-green-50 border border-green-200 p-3 text-xs text-green-700">
+          <p className="font-medium mb-1">Transaction pending...</p>
+          <p className="font-mono break-all">{txId}</p>
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded-lg bg-red-50 border border-red-200 p-3 text-xs text-red-700">
+          <p className="font-medium mb-1">Submission failed</p>
+          <p>{error}</p>
+          <button onClick={() => {}} className="mt-2 underline">Retry</button>
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-xs font-medium text-gray-700 mb-1">
+            Response Hash <span className="text-gray-400">(64 hex characters)</span>
+          </label>
+          <input
+            type="text"
+            value={responseHash}
+            onChange={(e) => setResponseHash(e.target.value)}
+            disabled={!!txId}
+            className={`w-full rounded-lg border px-3 py-2 text-xs font-mono focus:outline-none focus:ring-2 ${
+              responseHash && !hashValid
+                ? 'border-red-300 focus:ring-red-200'
+                : 'border-gray-300 focus:ring-primary-200'
+            }`}
+            placeholder="0000000000000000000000000000000000000000000000000000000000000000"
+          />
+          {responseHash && !hashValid && (
+            <p className="text-xs text-red-500 mt-1">Must be exactly 64 hex characters</p>
+          )}
+        </div>
+
+        <MerkleProofInput value={proofLines} onChange={setProofLines} disabled={!!txId} />
+
+        <button
+          onClick={() => setShowHelp((v) => !v)}
+          type="button"
+          className="text-xs text-blue-600 hover:underline"
+        >
+          {showHelp ? '▲ Hide' : '▼ What is a Merkle proof?'}
+        </button>
+
+        {showHelp && (
+          <div className="rounded-lg bg-blue-50 border border-blue-100 p-3 text-xs text-blue-800 space-y-1">
+            <p className="font-semibold">What is a Merkle proof?</p>
+            <p>A Merkle proof is a list of sibling hashes that lets a verifier reconstruct the root of a Merkle tree from a single leaf hash.</p>
+            <p>Each line should be a 64-character lowercase hex string (SHA-256 hash of the sibling node at that level).</p>
+          </div>
+        )}
+
+        {proofErrors.length > 0 && (
+          <ul className="text-xs text-red-500 list-disc pl-4 space-y-0.5">
+            {proofErrors.map((e, i) => <li key={i}>{e}</li>)}
+          </ul>
+        )}
+
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          className="w-full rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50 disabled:cursor-not-allowed hover:bg-primary-700 transition-colors"
+        >
+          {responding ? 'Submitting...' : 'Submit Response'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/components/ChallengeResponseForm.tsx
+++ b/frontend/src/components/ChallengeResponseForm.tsx
@@ -90,9 +90,16 @@ export default function ChallengeResponseForm({
       </div>
 
       {txId && (
-        <div className="rounded-lg bg-green-50 border border-green-200 p-3 text-xs text-green-700">
-          <p className="font-medium mb-1">Transaction pending...</p>
-          <p className="font-mono break-all">{txId}</p>
+        <div className="rounded-lg bg-green-50 border border-green-200 p-4 space-y-2">
+          <div className="flex items-center gap-2">
+            <svg className="animate-spin h-4 w-4 text-green-600" fill="none" viewBox="0 0 24 24">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
+            </svg>
+            <p className="text-xs font-semibold text-green-700">Transaction pending confirmation...</p>
+          </div>
+          <p className="text-xs text-green-600 font-mono break-all">{txId}</p>
+          <p className="text-xs text-green-500">Your response has been broadcast to the Stacks network. This may take a few minutes.</p>
         </div>
       )}
 

--- a/frontend/src/components/ChallengeStatusBadge.tsx
+++ b/frontend/src/components/ChallengeStatusBadge.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import type { ChallengeStatus } from '@/types/challenge';
+
+interface ChallengeStatusBadgeProps {
+  status: ChallengeStatus;
+}
+
+const STATUS_CONFIG: Record<
+  ChallengeStatus,
+  { label: string; bg: string; text: string; dot?: string; pulse?: boolean }
+> = {
+  pending: {
+    label: 'Pending',
+    bg: 'bg-yellow-100',
+    text: 'text-yellow-700',
+    dot: 'bg-yellow-500',
+    pulse: true,
+  },
+  responded: {
+    label: 'Responded',
+    bg: 'bg-blue-100',
+    text: 'text-blue-700',
+    dot: 'bg-blue-500',
+  },
+  validated: {
+    label: 'Validated',
+    bg: 'bg-green-100',
+    text: 'text-green-700',
+    dot: 'bg-green-500',
+  },
+  slashed: {
+    label: 'Slashed',
+    bg: 'bg-red-100',
+    text: 'text-red-700',
+    dot: 'bg-red-500',
+  },
+  expired: {
+    label: 'Expired',
+    bg: 'bg-gray-100',
+    text: 'text-gray-500',
+    dot: 'bg-gray-400',
+  },
+};
+
+export default function ChallengeStatusBadge({ status }: ChallengeStatusBadgeProps) {
+  const config = STATUS_CONFIG[status];
+  return (
+    <span className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${config.bg} ${config.text}`}>
+      {config.dot && (
+        <span className={`h-1.5 w-1.5 rounded-full ${config.dot} ${config.pulse ? 'animate-pulse' : ''}`} />
+      )}
+      {config.label}
+    </span>
+  );
+}

--- a/frontend/src/components/ChallengeTimeline.tsx
+++ b/frontend/src/components/ChallengeTimeline.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import type { ChallengeStatus } from '@/types/challenge';
+
+interface TimelineStep {
+  key: string;
+  label: string;
+  description: string;
+}
+
+const TIMELINE_STEPS: TimelineStep[] = [
+  { key: 'created', label: 'Created', description: 'Challenge submitted on-chain' },
+  { key: 'response-window', label: 'Response Window', description: '144 blocks to respond (~24 hours)' },
+  { key: 'outcome', label: 'Outcome', description: 'Responded, Expired, or Slashed' },
+  { key: 'finalized', label: 'Finalized', description: 'Validated or Slash executed' },
+];
+
+function getActiveStep(status: ChallengeStatus): number {
+  switch (status) {
+    case 'pending': return 1;
+    case 'responded': return 2;
+    case 'expired': return 2;
+    case 'slashed': return 3;
+    case 'validated': return 3;
+    default: return 0;
+  }
+}
+
+function getOutcomeLabel(status: ChallengeStatus): string {
+  switch (status) {
+    case 'responded': return 'Responded';
+    case 'expired': return 'Expired';
+    case 'slashed': return 'Slashed';
+    case 'validated': return 'Validated';
+    default: return 'Pending';
+  }
+}
+
+interface ChallengeTimelineProps {
+  status: ChallengeStatus;
+}
+
+export default function ChallengeTimeline({ status }: ChallengeTimelineProps) {
+  const activeStep = getActiveStep(status);
+  const outcomeLabel = getOutcomeLabel(status);
+
+  const steps = TIMELINE_STEPS.map((step, idx) => {
+    const label = step.key === 'outcome' ? outcomeLabel : step.label;
+    const isCurrent = idx === activeStep;
+    const isCompleted = idx < activeStep;
+    const isSlashed = status === 'slashed' && idx >= 2;
+    const isExpired = status === 'expired' && idx >= 2;
+
+    return { ...step, label, isCurrent, isCompleted, isSlashed, isExpired };
+  });
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-5">
+      <h3 className="text-sm font-semibold text-gray-900 mb-4">Challenge Lifecycle</h3>
+      <div className="flex items-start gap-0">
+        {steps.map((step, idx) => (
+          <div key={step.key} className="flex-1 flex items-start">
+            <div className="flex flex-col items-center w-full">
+              <div className="flex items-center w-full">
+                <div
+                  className={`challenge-timeline-dot flex-shrink-0 ${
+                    step.isCompleted
+                      ? 'bg-green-500 border-green-500 text-white'
+                      : step.isCurrent
+                      ? step.isSlashed
+                        ? 'bg-red-500 border-red-500 text-white'
+                        : 'bg-primary-600 border-primary-600 text-white'
+                      : 'border-gray-300 bg-white'
+                  }`}
+                />
+                {idx < steps.length - 1 && (
+                  <div
+                    className={`challenge-timeline-line ${
+                      step.isCompleted ? 'bg-green-500' : 'bg-gray-200'
+                    }`}
+                  />
+                )}
+              </div>
+              <div className="mt-2 text-center px-1">
+                <p
+                  className={`text-xs font-medium ${
+                    step.isCurrent
+                      ? step.isSlashed
+                        ? 'text-red-600'
+                        : step.isExpired
+                        ? 'text-gray-500'
+                        : 'text-primary-700'
+                      : step.isCompleted
+                      ? 'text-green-700'
+                      : 'text-gray-400'
+                  }`}
+                >
+                  {step.label}
+                </p>
+                <p className="text-xs text-gray-400 mt-0.5 leading-tight">{step.description}</p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/MerkleProofInput.tsx
+++ b/frontend/src/components/MerkleProofInput.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+const HEX64_PATTERN = /^[0-9a-fA-F]{64}$/;
+
+interface MerkleProofInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+}
+
+interface LineValidation {
+  hash: string;
+  valid: boolean;
+}
+
+export default function MerkleProofInput({ value, onChange, disabled = false }: MerkleProofInputProps) {
+  const lines: LineValidation[] = value
+    .split('\n')
+    .filter((l) => l.trim() !== '')
+    .map((l) => ({
+      hash: l.trim(),
+      valid: HEX64_PATTERN.test(l.trim()),
+    }));
+
+  const validCount = lines.filter((l) => l.valid).length;
+  const invalidCount = lines.length - validCount;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <label className="text-xs font-medium text-gray-700">
+          Merkle Proof <span className="text-gray-400">(one hash per line)</span>
+        </label>
+        {lines.length > 0 && (
+          <span className="text-xs">
+            <span className="text-green-600">{validCount} valid</span>
+            {invalidCount > 0 && (
+              <span className="text-red-500 ml-2">{invalidCount} invalid</span>
+            )}
+          </span>
+        )}
+      </div>
+
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        rows={6}
+        className="w-full rounded-lg border border-gray-300 px-3 py-2 text-xs font-mono focus:outline-none focus:ring-2 focus:ring-primary-200 resize-y disabled:opacity-50"
+        placeholder={`a1b2c3...d4e5f6\n0f1e2d...3c4b5a\n(paste proof hashes here)`}
+      />
+
+      {lines.length > 0 && (
+        <div className="space-y-1 max-h-40 overflow-y-auto">
+          {lines.map((line, idx) => (
+            <div key={idx} className="flex items-center gap-2 text-xs">
+              <span className={line.valid ? 'text-green-500' : 'text-red-500'}>
+                {line.valid ? '✓' : '✗'}
+              </span>
+              <span className="font-mono text-gray-500 truncate">
+                {line.hash.slice(0, 16)}…{line.hash.slice(-8)}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,9 +1,14 @@
 "use client";
 
 import { useWallet } from "@/hooks/useWallet";
+import { useFetchChallenges } from "@/hooks/useFetchChallenges";
 
 export default function Navbar() {
   const { isConnected, connect, disconnect, getAddress } = useWallet();
+  const { challenges } = useFetchChallenges();
+  const activeChallengeCount = challenges.filter(
+    (c) => c.status === 'pending' || c.status === 'responded'
+  ).length;
 
   return (
     <nav className="border-b border-gray-200 bg-white">
@@ -22,6 +27,14 @@ export default function Navbar() {
             </a>
             <a href="/providers" className="text-sm text-gray-600 hover:text-gray-900">
               Providers
+            </a>
+            <a href="/challenges" className="relative text-sm text-gray-600 hover:text-gray-900 flex items-center gap-1">
+              Challenges
+              {activeChallengeCount > 0 && (
+                <span className="absolute -top-2 -right-3 inline-flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-white text-[10px] font-bold">
+                  {activeChallengeCount}
+                </span>
+              )}
             </a>
             <a href="#how-it-works" className="text-sm text-gray-600 hover:text-gray-900">
               How It Works

--- a/frontend/src/components/SlashHistoryItem.tsx
+++ b/frontend/src/components/SlashHistoryItem.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import type { SlashEvent } from '@/types/challenge';
+
+interface SlashHistoryItemProps {
+  event: SlashEvent;
+}
+
+const REASON_LABEL: Record<SlashEvent['reason'], string> = {
+  'failed-challenge': 'Failed challenge response',
+  'late-response': 'Late response window',
+};
+
+function formatDate(ms: number): string {
+  return new Date(ms).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+export default function SlashHistoryItem({ event }: SlashHistoryItemProps) {
+  return (
+    <div className="flex items-start gap-3 rounded-xl border-l-4 border-l-red-500 border border-gray-200 bg-white px-4 py-3 shadow-sm">
+      <div className="mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-red-100 text-red-600 text-sm font-bold">
+        ⚠
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-start justify-between gap-2">
+          <div>
+            <p className="text-sm font-semibold text-gray-900">Provider #{event.providerId}</p>
+            <p className="text-xs text-gray-500 mt-0.5">{REASON_LABEL[event.reason]}</p>
+          </div>
+          <div className="text-right flex-shrink-0">
+            <p className="text-sm font-bold text-red-600">
+              -{(event.slashAmount / 1_000_000).toFixed(6)} STX
+            </p>
+            <p className="text-xs text-gray-400">{formatDate(event.timestamp)}</p>
+          </div>
+        </div>
+        <div className="mt-2 flex items-center gap-3 text-xs text-gray-400">
+          <span>Challenge: <span className="font-mono">{event.challengeId}</span></span>
+          <span>Block #{event.block}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useFetchChallenges.ts
+++ b/frontend/src/hooks/useFetchChallenges.ts
@@ -39,6 +39,17 @@ const MOCK_CHALLENGES: Challenge[] = [
   },
 ];
 
+interface ChallengeStats {
+  total: number;
+  pending: number;
+  responded: number;
+  validated: number;
+  slashed: number;
+  expired: number;
+  totalSlashAmountMicroStx: number;
+  responseRate: number;
+}
+
 interface UseFetchChallengesResult {
   challenges: Challenge[];
   loading: boolean;
@@ -46,6 +57,7 @@ interface UseFetchChallengesResult {
   refetch: () => void;
   getActiveChallengesForProvider: (providerId: number) => Challenge[];
   filterByStatus: (status: ChallengeStatus) => Challenge[];
+  getStats: () => ChallengeStats;
 }
 
 export function useFetchChallenges(): UseFetchChallengesResult {
@@ -82,5 +94,21 @@ export function useFetchChallenges(): UseFetchChallengesResult {
     [challenges]
   );
 
-  return { challenges, loading, error, refetch: load, getActiveChallengesForProvider, filterByStatus };
+  const getStats = useCallback((): ChallengeStats => {
+    const byStatus = (s: ChallengeStatus) => challenges.filter((c) => c.status === s).length;
+    const responded = challenges.filter((c) => c.responseHash != null).length;
+    const totalSlash = challenges.reduce((sum, c) => sum + (c.slashAmount ?? 0), 0);
+    return {
+      total: challenges.length,
+      pending: byStatus('pending'),
+      responded: byStatus('responded'),
+      validated: byStatus('validated'),
+      slashed: byStatus('slashed'),
+      expired: byStatus('expired'),
+      totalSlashAmountMicroStx: totalSlash,
+      responseRate: challenges.length > 0 ? Math.round((responded / challenges.length) * 100) : 0,
+    };
+  }, [challenges]);
+
+  return { challenges, loading, error, refetch: load, getActiveChallengesForProvider, filterByStatus, getStats };
 }

--- a/frontend/src/hooks/useFetchChallenges.ts
+++ b/frontend/src/hooks/useFetchChallenges.ts
@@ -1,0 +1,86 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import type { Challenge, ChallengeStatus } from '@/types/challenge';
+
+// Mock data — replace with contract event indexer integration
+const MOCK_CHALLENGES: Challenge[] = [
+  {
+    id: 'ch-001',
+    commitmentId: 3,
+    challenger: 'ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG',
+    providerId: 7,
+    challengeBlock: 144800,
+    responseDeadlineBlock: 144944,
+    status: 'pending',
+    createdAt: Date.now() - 1000 * 60 * 90,
+  },
+  {
+    id: 'ch-002',
+    commitmentId: 7,
+    challenger: 'ST2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1HR05NNC',
+    providerId: 3,
+    challengeBlock: 144600,
+    responseDeadlineBlock: 144744,
+    status: 'responded',
+    responseHash: 'a1b2c3d4e5f6' + '0'.repeat(52),
+    createdAt: Date.now() - 1000 * 60 * 180,
+  },
+  {
+    id: 'ch-003',
+    commitmentId: 1,
+    challenger: 'ST2REHHS5J3CERCRBEPMGH7921Q6PYKAADT7JP2VB',
+    providerId: 5,
+    challengeBlock: 144200,
+    responseDeadlineBlock: 144344,
+    status: 'slashed',
+    slashAmount: 5_000_000,
+    createdAt: Date.now() - 1000 * 60 * 60 * 6,
+  },
+];
+
+interface UseFetchChallengesResult {
+  challenges: Challenge[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+  getActiveChallengesForProvider: (providerId: number) => Challenge[];
+  filterByStatus: (status: ChallengeStatus) => Challenge[];
+}
+
+export function useFetchChallenges(): UseFetchChallengesResult {
+  const [challenges, setChallenges] = useState<Challenge[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      // TODO: replace with contract event indexer API call
+      await new Promise((r) => setTimeout(r, 100));
+      setChallenges(MOCK_CHALLENGES);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch challenges');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const getActiveChallengesForProvider = useCallback(
+    (providerId: number) =>
+      challenges.filter(
+        (c) => c.providerId === providerId && (c.status === 'pending' || c.status === 'responded')
+      ),
+    [challenges]
+  );
+
+  const filterByStatus = useCallback(
+    (status: ChallengeStatus) => challenges.filter((c) => c.status === status),
+    [challenges]
+  );
+
+  return { challenges, loading, error, refetch: load, getActiveChallengesForProvider, filterByStatus };
+}

--- a/frontend/src/hooks/useRespondToChallenge.ts
+++ b/frontend/src/hooks/useRespondToChallenge.ts
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+
+interface UseRespondToChallengeResult {
+  responding: boolean;
+  error: string | null;
+  txId: string | null;
+  respond: (challengeId: string, responseHash: string, merkleProof: string[]) => Promise<void>;
+}
+
+export function useRespondToChallenge(): UseRespondToChallengeResult {
+  const [responding, setResponding] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [txId, setTxId] = useState<string | null>(null);
+
+  const respond = useCallback(
+    async (challengeId: string, responseHash: string, merkleProof: string[]) => {
+      setResponding(true);
+      setError(null);
+      setTxId(null);
+
+      try {
+        const { openContractCall } = await import('@stacks/connect');
+
+        const contractCallOptions = {
+          contractAddress: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM',
+          contractName: 'registry',
+          functionName: 'respond-to-challenge',
+          functionArgs: [
+            // challenge-id (uint)
+            { type: 'uint', value: challengeId.replace('ch-', '') },
+            // response-hash (buff 32)
+            { type: 'buff', value: responseHash },
+            // merkle-proof (list of buff 32)
+            {
+              type: 'list',
+              value: merkleProof.map((p) => ({ type: 'buff', value: p })),
+            },
+          ],
+          onFinish: (result: { txId: string }) => {
+            setTxId(result.txId);
+            setResponding(false);
+          },
+          onCancel: () => {
+            setError('Transaction cancelled.');
+            setResponding(false);
+          },
+        };
+
+        await openContractCall(contractCallOptions as Parameters<typeof openContractCall>[0]);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to submit response');
+        setResponding(false);
+      }
+    },
+    []
+  );
+
+  return { responding, error, txId, respond };
+}

--- a/frontend/src/lib/challengeUtils.ts
+++ b/frontend/src/lib/challengeUtils.ts
@@ -1,0 +1,79 @@
+import type { Challenge, ChallengeStatus } from '@/types/challenge';
+
+export const CHALLENGE_RESPONSE_BLOCKS = 144; // ~24 hours at 10 min/block
+
+export function isResponseDeadlinePassed(challenge: Challenge, currentBlock: number): boolean {
+  return currentBlock > challenge.responseDeadlineBlock;
+}
+
+export function getBlocksUntilDeadline(challenge: Challenge, currentBlock: number): number {
+  return Math.max(0, challenge.responseDeadlineBlock - currentBlock);
+}
+
+export function formatDeadline(blocksRemaining: number): string {
+  if (blocksRemaining === 0) return 'Deadline passed';
+  const totalMinutes = blocksRemaining * 10;
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours === 0) return `${minutes} minutes`;
+  if (minutes === 0) return `${hours} hours`;
+  return `${hours} hours ${minutes} minutes`;
+}
+
+export function getChallengeStatusColor(status: ChallengeStatus): string {
+  const colors: Record<ChallengeStatus, string> = {
+    pending: 'text-yellow-600',
+    responded: 'text-blue-600',
+    validated: 'text-green-600',
+    slashed: 'text-red-600',
+    expired: 'text-gray-500',
+  };
+  return colors[status];
+}
+
+export function canRespond(
+  challenge: Challenge,
+  providerOwner: string,
+  connectedAddress: string,
+  currentBlock: number
+): boolean {
+  return (
+    challenge.status === 'pending' &&
+    providerOwner.toLowerCase() === connectedAddress.toLowerCase() &&
+    !isResponseDeadlinePassed(challenge, currentBlock)
+  );
+}
+
+export function getResponseWindowProgress(challenge: Challenge, currentBlock: number): number {
+  const elapsed = currentBlock - challenge.challengeBlock;
+  const total = CHALLENGE_RESPONSE_BLOCKS;
+  return Math.min(100, Math.round((elapsed / total) * 100));
+}
+
+export function shouldAlert(challenge: Challenge, currentBlock: number): boolean {
+  const progress = getResponseWindowProgress(challenge, currentBlock);
+  return challenge.status === 'pending' && progress >= 80;
+}
+
+export function estimateSlashAmount(staked: number): number {
+  return Math.floor(staked * 0.1);
+}
+
+export function validateMerkleProof(proof: string[]): { valid: boolean; errors: string[] } {
+  const errors: string[] = [];
+  const hexPattern = /^[0-9a-fA-F]{64}$/;
+  proof.forEach((hash, i) => {
+    if (!hexPattern.test(hash)) {
+      errors.push(`Line ${i + 1}: must be exactly 64 hex characters`);
+    }
+  });
+  return { valid: errors.length === 0, errors };
+}
+
+export function hashToBuffer(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+  }
+  return bytes;
+}

--- a/frontend/src/lib/challengeUtils.ts
+++ b/frontend/src/lib/challengeUtils.ts
@@ -78,6 +78,21 @@ export function hashToBuffer(hex: string): Uint8Array {
   return bytes;
 }
 
+export function formatBlockTime(blocks: number): string {
+  const totalSeconds = blocks * 10 * 60;
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}
+
+export function estimatedDeadlineTimestamp(challenge: Challenge, currentBlock: number): number {
+  const blocksLeft = getBlocksUntilDeadline(challenge, currentBlock);
+  return Date.now() + blocksLeft * 10 * 60 * 1000;
+}
+
 export function bufferToHex(bytes: Uint8Array): string {
   return Array.from(bytes)
     .map((b) => b.toString(16).padStart(2, '0'))

--- a/frontend/src/lib/challengeUtils.ts
+++ b/frontend/src/lib/challengeUtils.ts
@@ -77,3 +77,38 @@ export function hashToBuffer(hex: string): Uint8Array {
   }
   return bytes;
 }
+
+export function bufferToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/** SHA-256 via WebCrypto — available in browser and Node 18+ */
+export async function sha256Hex(data: Uint8Array): Promise<string> {
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  return bufferToHex(new Uint8Array(hashBuffer));
+}
+
+/** Verify a single Merkle path by walking proof hashes from leaf to root */
+export async function verifyMerklePath(
+  chunkHash: string,
+  proof: string[],
+  root: string,
+  index: number
+): Promise<boolean> {
+  let current = chunkHash.toLowerCase();
+  let idx = index;
+
+  for (const sibling of proof) {
+    const sib = sibling.toLowerCase();
+    const isLeft = idx % 2 === 0;
+    const left = isLeft ? current : sib;
+    const right = isLeft ? sib : current;
+    const combined = hashToBuffer(left + right);
+    current = await sha256Hex(combined);
+    idx = Math.floor(idx / 2);
+  }
+
+  return current === root.toLowerCase();
+}

--- a/frontend/src/types/challenge.ts
+++ b/frontend/src/types/challenge.ts
@@ -1,0 +1,31 @@
+export type ChallengeStatus = 'pending' | 'responded' | 'validated' | 'slashed' | 'expired';
+
+export interface Challenge {
+  id: string;
+  commitmentId: number;
+  challenger: string;
+  providerId: number;
+  challengeBlock: number;
+  responseDeadlineBlock: number;
+  status: ChallengeStatus;
+  slashAmount?: number;
+  responseHash?: string;
+  createdAt: number; // ms timestamp
+}
+
+export interface ChallengeResponse {
+  challengeId: string;
+  responseHash: string;
+  merkleProof: string[];
+  respondedAt: number; // ms timestamp
+  txHash: string;
+}
+
+export interface SlashEvent {
+  challengeId: string;
+  providerId: number;
+  slashAmount: number; // microSTX
+  reason: 'failed-challenge' | 'late-response';
+  block: number;
+  timestamp: number;
+}


### PR DESCRIPTION
## Summary
- Add challenge type system with ChallengeStatus enum and SlashEvent interface
- Add challengeUtils with deadline calculation, Merkle proof validation, and WebCrypto path verification
- Add useFetchChallenges hook with mock data, status filters, and getStats helper
- Add useRespondToChallenge hook with dynamic @stacks/connect import
- Add ChallengeCard, ChallengeStatusBadge, ChallengeResponseForm, MerkleProofInput, ChallengeTimeline, SlashHistoryItem components
- Add challenges listing page with active/resolved tabs and summary stats
- Add challenge detail page with timeline and response form
- Add Challenges nav link with active challenge count badge to Navbar