### PR TITLE
Add commitment status and Merkle proof viewer

### DIFF
--- a/frontend/src/app/commitments/[id]/page.tsx
+++ b/frontend/src/app/commitments/[id]/page.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { use, useState } from 'react';
+import { useFetchCommitment } from '@/hooks/useFetchCommitment';
+import { useCompleteCommitment } from '@/hooks/useCompleteCommitment';
+import DataRootDisplay from '@/components/DataRootDisplay';
+import MerkleVerifier from '@/components/MerkleVerifier';
+import CommitmentProgressBar from '@/components/CommitmentProgressBar';
+import { formatStorageSize, formatDuration } from '@/lib/commitmentUtils';
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+const CONNECTED_ADDRESS = ''; // wire to wallet context in production
+
+export default function CommitmentDetailPage({ params }: PageProps) {
+  const { id } = use(params);
+  const commitmentId = parseInt(id, 10);
+  const { commitment, summary, loading } = useFetchCommitment(commitmentId);
+  const { completing, error: completeError, txId, completeCommitment } = useCompleteCommitment();
+  const [showVerifier, setShowVerifier] = useState(false);
+
+  if (loading) {
+    return (
+      <main className="mx-auto max-w-4xl px-4 py-10">
+        <div className="animate-pulse space-y-4">
+          <div className="h-8 w-56 rounded bg-gray-200" />
+          <div className="h-32 rounded-xl bg-gray-100" />
+        </div>
+      </main>
+    );
+  }
+
+  if (!commitment || !summary) {
+    return (
+      <main className="mx-auto max-w-4xl px-4 py-10">
+        <p className="text-gray-500">Commitment #{commitmentId} not found.</p>
+      </main>
+    );
+  }
+
+  const isOwner = CONNECTED_ADDRESS.toLowerCase() === commitment.dataOwner.toLowerCase();
+  const canComplete = isOwner && (summary.status === 'completed' || summary.status === 'expired');
+
+  return (
+    <main className="mx-auto max-w-4xl px-4 py-10 space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Commitment #{commitmentId}</h1>
+          <p className="text-xs text-gray-400 mt-0.5">Provider #{commitment.providerId}</p>
+        </div>
+        {canComplete && (
+          <button
+            onClick={() => completeCommitment(commitmentId)}
+            disabled={completing || !!txId}
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50 hover:bg-blue-700"
+          >
+            {completing ? 'Completing...' : 'Complete Commitment'}
+          </button>
+        )}
+      </div>
+
+      {txId && (
+        <div className="rounded-lg bg-green-50 border border-green-200 p-3 text-xs text-green-700">
+          Transaction broadcast: <span className="font-mono">{txId}</span>
+        </div>
+      )}
+      {completeError && (
+        <div className="rounded-lg bg-red-50 border border-red-200 p-3 text-xs text-red-700">{completeError}</div>
+      )}
+
+      <CommitmentProgressBar percentComplete={summary.percentComplete} status={summary.status} />
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {[
+          { label: 'Storage', value: formatStorageSize(commitment.storageSizeMb) },
+          { label: 'Chunks', value: commitment.chunkCount.toString() },
+          { label: 'Duration', value: formatDuration(commitment.durationBlocks) },
+          { label: 'Stake Required', value: `${(commitment.stakeRequired / 1_000_000).toFixed(6)} STX` },
+          { label: 'Start Block', value: `#${commitment.startBlock}` },
+          { label: 'End Block', value: `#${commitment.endBlock}` },
+          { label: 'Blocks Remaining', value: summary.blocksRemaining.toLocaleString() },
+          { label: 'Data Owner', value: `${commitment.dataOwner.slice(0, 8)}…` },
+        ].map(({ label, value }) => (
+          <div key={label} className="rounded-xl border border-gray-200 bg-white p-4">
+            <p className="text-xs text-gray-500">{label}</p>
+            <p className="font-semibold text-gray-800 text-sm mt-1 truncate" title={value}>{value}</p>
+          </div>
+        ))}
+      </div>
+
+      <DataRootDisplay
+        dataRoot={commitment.dataRoot}
+        onVerify={() => setShowVerifier((v) => !v)}
+      />
+
+      {showVerifier && (
+        <MerkleVerifier dataRoot={commitment.dataRoot} chunkCount={commitment.chunkCount} />
+      )}
+    </main>
+  );
+}

--- a/frontend/src/app/commitments/page.tsx
+++ b/frontend/src/app/commitments/page.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import { Suspense } from 'react';
+import { useFetchCommitments } from '@/hooks/useFetchCommitments';
+import CommitmentList from '@/components/CommitmentList';
+import { formatStorageSize } from '@/lib/commitmentUtils';
+
+function CommitmentsContent() {
+  const searchParams = useSearchParams();
+  const providerParam = searchParams.get('provider');
+  const providerId = providerParam ? parseInt(providerParam, 10) : undefined;
+
+  const { commitments, loading, error } = useFetchCommitments({ providerId });
+
+  const activeCount = commitments.filter((s) => s.status === 'active' || s.status === 'expiring-soon').length;
+  const totalStorage = commitments.reduce((sum, s) => sum + s.commitment.storageSizeMb, 0);
+  const totalStake = commitments.reduce((sum, s) => sum + s.commitment.stakeRequired, 0);
+
+  return (
+    <main className="mx-auto max-w-6xl px-4 py-10 space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Commitments</h1>
+        <p className="text-sm text-gray-500 mt-1">
+          Storage commitments registered on VerifyChain.
+          {providerId && <span className="ml-1 font-medium">Filtered by Provider #{providerId}</span>}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-3 gap-4">
+        <div className="rounded-xl border border-gray-200 bg-white p-4 text-center">
+          <p className="text-2xl font-bold text-green-600">{activeCount}</p>
+          <p className="text-xs text-gray-500 mt-1">Active Commitments</p>
+        </div>
+        <div className="rounded-xl border border-gray-200 bg-white p-4 text-center">
+          <p className="text-2xl font-bold text-blue-600">{formatStorageSize(totalStorage)}</p>
+          <p className="text-xs text-gray-500 mt-1">Total Storage Verified</p>
+        </div>
+        <div className="rounded-xl border border-gray-200 bg-white p-4 text-center">
+          <p className="text-2xl font-bold text-gray-800">{(totalStake / 1_000_000).toFixed(0)}</p>
+          <p className="text-xs text-gray-500 mt-1">STX Stake Locked</p>
+        </div>
+      </div>
+
+      {error && <p className="text-sm text-red-500">{error}</p>}
+
+      <CommitmentList commitments={commitments} loading={loading} />
+    </main>
+  );
+}
+
+export default function CommitmentsPage() {
+  return (
+    <Suspense fallback={<div className="mx-auto max-w-6xl px-4 py-10 animate-pulse h-64 bg-gray-100 rounded-xl" />}>
+      <CommitmentsContent />
+    </Suspense>
+  );
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -36,6 +36,33 @@
   }
 }
 
+/* Commitment viewer styles */
+.commitment-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 20px;
+}
+.commitment-progress {
+  height: 6px;
+  border-radius: 3px;
+  background: #f3f4f6;
+  overflow: hidden;
+}
+.data-root-display {
+  font-family: 'Courier New', monospace;
+  font-size: 0.8rem;
+  word-break: break-all;
+  background: #f9fafb;
+  padding: 8px 12px;
+  border-radius: 6px;
+  border: 1px solid #e5e7eb;
+}
+.merkle-step {
+  border-left: 2px solid #e5e7eb;
+  padding-left: 12px;
+  margin-left: 6px;
+}
+
 /* Challenge protocol styles */
 .challenge-card {
   border-left: 4px solid #f59e0b;

--- a/frontend/src/components/CommitmentCard.tsx
+++ b/frontend/src/components/CommitmentCard.tsx
@@ -57,7 +57,10 @@ export default function CommitmentCard({ summary, connectedAddress, onComplete }
         </div>
         <div>
           <p className="text-xs text-gray-500">Stake Locked</p>
-          <p className="font-semibold text-gray-800">{stakeInStx} STX</p>
+          <p className="font-semibold text-gray-800" title={`${commitment.stakeRequired} microSTX`}>
+            {stakeInStx} STX
+          </p>
+          <p className="text-xs text-gray-400">{commitment.stakeRequired.toLocaleString()} µSTX</p>
         </div>
       </div>
 

--- a/frontend/src/components/CommitmentCard.tsx
+++ b/frontend/src/components/CommitmentCard.tsx
@@ -63,24 +63,33 @@ export default function CommitmentCard({ summary, connectedAddress, onComplete }
 
       <CommitmentProgressBar percentComplete={percentComplete} status={status} />
 
-      {isOwner && (status === 'completed' || status === 'expired') && onComplete && (
-        <button
-          onClick={(e) => { e.stopPropagation(); onComplete(commitment.id); }}
-          className="mt-3 w-full rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700"
-        >
-          Complete Commitment
-        </button>
-      )}
-
-      {status === 'active' && (
+      <div className="mt-3 flex items-center gap-2">
+        {isOwner && (status === 'completed' || status === 'expired') && onComplete && (
+          <button
+            onClick={(e) => { e.stopPropagation(); onComplete(commitment.id); }}
+            className="flex-1 rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700"
+            title="Call complete-commitment on the registry contract to release stake"
+          >
+            Complete Commitment
+          </button>
+        )}
+        {status === 'active' && (
+          <button
+            onClick={(e) => { e.stopPropagation(); router.push(`/commitments/${commitment.id}`); }}
+            className="rounded-lg border border-primary-300 bg-primary-50 px-3 py-1.5 text-xs font-medium text-primary-700 hover:bg-primary-100"
+            title="Open Merkle proof verifier for this commitment"
+          >
+            View Proof
+          </button>
+        )}
         <button
           onClick={(e) => { e.stopPropagation(); router.push(`/commitments/${commitment.id}`); }}
-          className="mt-3 text-xs text-primary-600 hover:underline"
-          title="View Merkle proof for this commitment"
+          className="ml-auto text-xs text-gray-400 hover:text-gray-600"
+          title="Open commitment detail page"
         >
-          View Proof →
+          Details →
         </button>
-      )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/CommitmentCard.tsx
+++ b/frontend/src/components/CommitmentCard.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import type { CommitmentSummary, CommitmentStatus } from '@/types/commitment';
+import { formatStorageSize } from '@/lib/commitmentUtils';
+import CommitmentProgressBar from './CommitmentProgressBar';
+
+interface CommitmentCardProps {
+  summary: CommitmentSummary;
+  connectedAddress?: string;
+  onComplete?: (id: number) => void;
+}
+
+const STATUS_BADGE: Record<CommitmentStatus, { label: string; bg: string; text: string }> = {
+  active: { label: 'Active', bg: 'bg-green-100', text: 'text-green-700' },
+  'expiring-soon': { label: 'Expiring Soon', bg: 'bg-yellow-100', text: 'text-yellow-700' },
+  expired: { label: 'Expired', bg: 'bg-gray-100', text: 'text-gray-500' },
+  completed: { label: 'Completed', bg: 'bg-blue-100', text: 'text-blue-700' },
+};
+
+function truncateHash(hash: string): string {
+  return `${hash.slice(0, 8)}...${hash.slice(-4)}`;
+}
+
+export default function CommitmentCard({ summary, connectedAddress, onComplete }: CommitmentCardProps) {
+  const router = useRouter();
+  const { commitment, status, blocksRemaining, percentComplete } = summary;
+  const badge = STATUS_BADGE[status];
+  const isOwner = connectedAddress?.toLowerCase() === commitment.dataOwner.toLowerCase();
+  const stakeInStx = (commitment.stakeRequired / 1_000_000).toFixed(6);
+
+  return (
+    <div className="commitment-card bg-white shadow-sm hover:shadow-md transition-shadow cursor-pointer"
+      onClick={() => router.push(`/commitments/${commitment.id}`)}>
+      <div className="flex items-start justify-between mb-4">
+        <div>
+          <p className="text-sm font-semibold text-gray-900">Commitment #{commitment.id}</p>
+          <p className="text-xs text-gray-400 font-mono mt-0.5">{truncateHash(commitment.dataRoot)}</p>
+        </div>
+        <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${badge.bg} ${badge.text}`}>
+          {badge.label}
+        </span>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 text-sm mb-4">
+        <div>
+          <p className="text-xs text-gray-500">Storage</p>
+          <p className="font-semibold text-gray-800">{formatStorageSize(commitment.storageSizeMb)}</p>
+        </div>
+        <div>
+          <p className="text-xs text-gray-500">Chunks</p>
+          <p className="font-semibold text-gray-800">{commitment.chunkCount}</p>
+        </div>
+        <div>
+          <p className="text-xs text-gray-500">Blocks Left</p>
+          <p className="font-semibold text-gray-800">{blocksRemaining.toLocaleString()}</p>
+        </div>
+        <div>
+          <p className="text-xs text-gray-500">Stake Locked</p>
+          <p className="font-semibold text-gray-800">{stakeInStx} STX</p>
+        </div>
+      </div>
+
+      <CommitmentProgressBar percentComplete={percentComplete} status={status} />
+
+      {isOwner && (status === 'completed' || status === 'expired') && onComplete && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onComplete(commitment.id); }}
+          className="mt-3 w-full rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700"
+        >
+          Complete Commitment
+        </button>
+      )}
+
+      {status === 'active' && (
+        <button
+          onClick={(e) => { e.stopPropagation(); router.push(`/commitments/${commitment.id}`); }}
+          className="mt-3 text-xs text-primary-600 hover:underline"
+          title="View Merkle proof for this commitment"
+        >
+          View Proof →
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/CommitmentList.tsx
+++ b/frontend/src/components/CommitmentList.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useState } from 'react';
+import type { CommitmentSummary, CommitmentStatus } from '@/types/commitment';
+import { formatStorageSize } from '@/lib/commitmentUtils';
+import CommitmentCard from './CommitmentCard';
+
+interface CommitmentListProps {
+  commitments: CommitmentSummary[];
+  loading?: boolean;
+  connectedAddress?: string;
+  onComplete?: (id: number) => void;
+}
+
+type FilterKey = 'all' | CommitmentStatus;
+
+export default function CommitmentList({ commitments, loading, connectedAddress, onComplete }: CommitmentListProps) {
+  const [filter, setFilter] = useState<FilterKey>('all');
+
+  const filtered = filter === 'all'
+    ? commitments
+    : commitments.filter((s) => s.status === filter);
+
+  const activeCount = commitments.filter((s) => s.status === 'active' || s.status === 'expiring-soon').length;
+  const totalStorage = commitments.reduce((sum, s) => sum + s.commitment.storageSizeMb, 0);
+  const totalStake = commitments.reduce((sum, s) => sum + s.commitment.stakeRequired, 0);
+
+  const FILTER_OPTIONS: { key: FilterKey; label: string }[] = [
+    { key: 'all', label: 'All' },
+    { key: 'active', label: 'Active' },
+    { key: 'expiring-soon', label: 'Expiring' },
+    { key: 'completed', label: 'Completed' },
+    { key: 'expired', label: 'Expired' },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-4 rounded-xl border border-gray-200 bg-white p-4">
+        <div className="flex gap-6 text-sm">
+          <div>
+            <span className="text-2xl font-bold text-gray-900">{activeCount}</span>
+            <p className="text-xs text-gray-500">Active</p>
+          </div>
+          <div>
+            <span className="text-2xl font-bold text-gray-900">{formatStorageSize(totalStorage)}</span>
+            <p className="text-xs text-gray-500">Total Storage</p>
+          </div>
+          <div>
+            <span className="text-2xl font-bold text-gray-900">{(totalStake / 1_000_000).toFixed(0)}</span>
+            <p className="text-xs text-gray-500">STX Locked</p>
+          </div>
+        </div>
+        <div className="flex gap-1 flex-wrap">
+          {FILTER_OPTIONS.map((opt) => (
+            <button
+              key={opt.key}
+              onClick={() => setFilter(opt.key)}
+              className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                filter === opt.key
+                  ? 'bg-primary-600 text-white'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {loading && (
+        <div className="space-y-3">
+          {[1, 2, 3].map((n) => (
+            <div key={n} className="animate-pulse h-40 rounded-xl bg-gray-100" />
+          ))}
+        </div>
+      )}
+
+      {!loading && filtered.length === 0 && (
+        <div className="py-12 text-center">
+          <p className="text-gray-400 text-sm">No commitments found</p>
+          <p className="text-gray-300 text-xs mt-1">Try changing the filter above</p>
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {filtered.map((summary) => (
+          <CommitmentCard
+            key={summary.commitment.id}
+            summary={summary}
+            connectedAddress={connectedAddress}
+            onComplete={onComplete}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/CommitmentProgressBar.tsx
+++ b/frontend/src/components/CommitmentProgressBar.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import type { CommitmentStatus } from '@/types/commitment';
+
+interface CommitmentProgressBarProps {
+  percentComplete: number;
+  status: CommitmentStatus;
+}
+
+function getFillColor(pct: number, status: CommitmentStatus): string {
+  if (status === 'expired' || status === 'completed') return 'bg-blue-500';
+  if (pct <= 50) return 'bg-blue-500';
+  if (pct <= 85) return 'bg-green-500';
+  if (pct <= 95) return 'bg-yellow-400';
+  return 'bg-purple-500';
+}
+
+function getLabelColor(pct: number, status: CommitmentStatus): string {
+  if (status === 'expired' || status === 'completed') return 'text-blue-600';
+  if (pct <= 50) return 'text-blue-600';
+  if (pct <= 85) return 'text-green-600';
+  if (pct <= 95) return 'text-yellow-600';
+  return 'text-purple-600';
+}
+
+export default function CommitmentProgressBar({ percentComplete, status }: CommitmentProgressBarProps) {
+  const clamped = Math.min(100, Math.max(0, percentComplete));
+  const fillColor = getFillColor(clamped, status);
+  const labelColor = getLabelColor(clamped, status);
+
+  return (
+    <div>
+      <div className="flex justify-between items-center mb-1">
+        <span className="text-xs text-gray-500">Progress</span>
+        <span className={`text-xs font-semibold ${labelColor}`}>{clamped}%</span>
+      </div>
+      <div className="commitment-progress">
+        <div
+          className={`h-full ${fillColor} transition-all duration-700`}
+          style={{ width: `${clamped}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/DataRootDisplay.tsx
+++ b/frontend/src/components/DataRootDisplay.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useState } from 'react';
+
+interface DataRootDisplayProps {
+  dataRoot: string; // 32-byte hex (64 chars)
+  onVerify?: () => void;
+}
+
+export default function DataRootDisplay({ dataRoot, onVerify }: DataRootDisplayProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const displayHash = expanded
+    ? dataRoot
+    : `${dataRoot.slice(0, 16)}…${dataRoot.slice(-8)}`;
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(dataRoot);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // fallback
+    }
+  };
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <p className="text-xs font-semibold text-gray-700">Data Root (Merkle Root)</p>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setExpanded((v) => !v)}
+            className="text-xs text-blue-600 hover:underline"
+          >
+            {expanded ? 'Collapse' : 'Expand'}
+          </button>
+          <button
+            onClick={handleCopy}
+            className="flex items-center gap-1 rounded bg-gray-100 px-2 py-1 text-xs text-gray-600 hover:bg-gray-200 transition-colors"
+            title="Copy to clipboard"
+          >
+            {copied ? '✓ Copied' : '⧉ Copy'}
+          </button>
+        </div>
+      </div>
+
+      <div className="data-root-display">
+        {displayHash}
+      </div>
+
+      {onVerify && (
+        <button
+          onClick={onVerify}
+          className="w-full rounded-lg border border-blue-300 bg-blue-50 px-3 py-2 text-xs font-medium text-blue-700 hover:bg-blue-100 transition-colors"
+        >
+          Verify Chunk Inclusion Proof
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/MerkleVerifier.tsx
+++ b/frontend/src/components/MerkleVerifier.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import { useState } from 'react';
+import { verifyMerklePath } from '@/lib/challengeUtils';
+
+interface VerificationStep {
+  level: number;
+  left: string;
+  right: string;
+  result: string;
+}
+
+interface MerkleVerifierProps {
+  dataRoot: string;
+  chunkCount: number;
+}
+
+export default function MerkleVerifier({ dataRoot, chunkCount }: MerkleVerifierProps) {
+  const [chunkIndex, setChunkIndex] = useState(0);
+  const [chunkHash, setChunkHash] = useState('');
+  const [proofText, setProofText] = useState('');
+  const [steps, setSteps] = useState<VerificationStep[]>([]);
+  const [result, setResult] = useState<boolean | null>(null);
+  const [verifying, setVerifying] = useState(false);
+  const [expandedSteps, setExpandedSteps] = useState<Set<number>>(new Set());
+
+  const proof = proofText
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+
+  const handlePasteProof = async () => {
+    try {
+      const text = await navigator.clipboard.readText();
+      setProofText(text);
+    } catch {
+      // clipboard not available
+    }
+  };
+
+  const handleVerify = async () => {
+    if (!chunkHash || proof.length === 0) return;
+    setVerifying(true);
+    setSteps([]);
+    setResult(null);
+
+    try {
+      // Run the path verification and collect steps
+      const collectedSteps: VerificationStep[] = [];
+      let current = chunkHash.toLowerCase();
+      let idx = chunkIndex;
+
+      for (let level = 0; level < proof.length; level++) {
+        const sibling = proof[level].toLowerCase();
+        const isLeft = idx % 2 === 0;
+        const left = isLeft ? current : sibling;
+        const right = isLeft ? sibling : current;
+
+        // Hash the concatenated pair
+        const combined = new Uint8Array(64);
+        for (let i = 0; i < 32; i++) {
+          combined[i] = parseInt(left.slice(i * 2, i * 2 + 2), 16);
+          combined[i + 32] = parseInt(right.slice(i * 2, i * 2 + 2), 16);
+        }
+        const hashBuffer = await crypto.subtle.digest('SHA-256', combined);
+        const hashHex = Array.from(new Uint8Array(hashBuffer))
+          .map((b) => b.toString(16).padStart(2, '0'))
+          .join('');
+
+        collectedSteps.push({ level, left, right, result: hashHex });
+        current = hashHex;
+        idx = Math.floor(idx / 2);
+      }
+
+      setSteps(collectedSteps);
+      const valid = await verifyMerklePath(chunkHash, proof, dataRoot, chunkIndex);
+      setResult(valid);
+    } catch {
+      setResult(false);
+    } finally {
+      setVerifying(false);
+    }
+  };
+
+  const toggleStep = (level: number) => {
+    setExpandedSteps((prev) => {
+      const next = new Set(prev);
+      if (next.has(level)) next.delete(level);
+      else next.add(level);
+      return next;
+    });
+  };
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-5 space-y-4">
+      <h3 className="text-sm font-semibold text-gray-900">Merkle Proof Verifier</h3>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="block text-xs font-medium text-gray-700 mb-1">
+            Chunk Index (0–{Math.max(0, chunkCount - 1)})
+          </label>
+          <input
+            type="number"
+            min={0}
+            max={chunkCount - 1}
+            value={chunkIndex}
+            onChange={(e) => setChunkIndex(parseInt(e.target.value, 10) || 0)}
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-200"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-gray-700 mb-1">Chunk Hash (64 hex)</label>
+          <input
+            type="text"
+            value={chunkHash}
+            onChange={(e) => setChunkHash(e.target.value)}
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-xs font-mono focus:outline-none focus:ring-2 focus:ring-primary-200"
+            placeholder="a1b2c3...d4e5f6"
+          />
+        </div>
+      </div>
+
+      <div>
+        <div className="flex items-center justify-between mb-1">
+          <label className="text-xs font-medium text-gray-700">Proof (one hash per line)</label>
+          <button onClick={handlePasteProof} className="text-xs text-blue-600 hover:underline">
+            Paste from clipboard
+          </button>
+        </div>
+        <textarea
+          value={proofText}
+          onChange={(e) => setProofText(e.target.value)}
+          rows={5}
+          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-xs font-mono focus:outline-none focus:ring-2 focus:ring-primary-200 resize-y"
+          placeholder="sibling hash per line..."
+        />
+      </div>
+
+      <button
+        onClick={handleVerify}
+        disabled={verifying || !chunkHash || proof.length === 0}
+        className="w-full rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50 hover:bg-primary-700 transition-colors"
+      >
+        {verifying ? 'Verifying...' : 'Verify Proof'}
+      </button>
+
+      {result !== null && (
+        <div className={`rounded-lg p-3 text-sm font-medium ${result ? 'bg-green-50 text-green-700 border border-green-200' : 'bg-red-50 text-red-700 border border-red-200'}`}>
+          {result ? '✓ Proof valid — chunk is included in the Merkle tree' : '✗ Proof invalid — hash mismatch at root'}
+        </div>
+      )}
+
+      {steps.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-xs font-semibold text-gray-700">Verification Path</p>
+          {steps.map((step) => (
+            <div key={step.level} className="merkle-step">
+              <button
+                onClick={() => toggleStep(step.level)}
+                className="flex items-center gap-2 text-xs text-gray-600 hover:text-gray-900"
+              >
+                <span>{expandedSteps.has(step.level) ? '▼' : '▶'}</span>
+                <span>Level {step.level} → <span className="font-mono">{step.result.slice(0, 12)}…</span></span>
+              </button>
+              {expandedSteps.has(step.level) && (
+                <div className="mt-2 space-y-1 text-xs font-mono text-gray-500">
+                  <p>L: {step.left}</p>
+                  <p>R: {step.right}</p>
+                  <p className="text-gray-800">→ {step.result}</p>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/MerkleVerifier.tsx
+++ b/frontend/src/components/MerkleVerifier.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { verifyMerklePath } from '@/lib/challengeUtils';
+import { buildMerkleTree, getProofForIndex, bytesToHex } from '@/lib/merkleUtils';
 
 interface VerificationStep {
   level: number;
@@ -23,6 +24,25 @@ export default function MerkleVerifier({ dataRoot, chunkCount }: MerkleVerifierP
   const [result, setResult] = useState<boolean | null>(null);
   const [verifying, setVerifying] = useState(false);
   const [expandedSteps, setExpandedSteps] = useState<Set<number>>(new Set());
+  const [generatingProof, setGeneratingProof] = useState(false);
+
+  const handleGenerateTestProof = async () => {
+    if (!chunkHash) return;
+    setGeneratingProof(true);
+    try {
+      // Build a test tree from the provided chunkHash as a leaf, padded to chunkCount leaves
+      const leaves: string[] = Array.from({ length: Math.max(2, chunkCount) }, (_, i) =>
+        i === chunkIndex ? chunkHash : bytesToHex(new Uint8Array(32).fill(i))
+      );
+      const tree = await buildMerkleTree(leaves);
+      const proof = getProofForIndex(tree, chunkIndex);
+      setProofText(proof.join('\n'));
+    } catch {
+      // ignore
+    } finally {
+      setGeneratingProof(false);
+    }
+  };
 
   const proof = proofText
     .split('\n')
@@ -124,9 +144,18 @@ export default function MerkleVerifier({ dataRoot, chunkCount }: MerkleVerifierP
       <div>
         <div className="flex items-center justify-between mb-1">
           <label className="text-xs font-medium text-gray-700">Proof (one hash per line)</label>
-          <button onClick={handlePasteProof} className="text-xs text-blue-600 hover:underline">
-            Paste from clipboard
-          </button>
+          <div className="flex gap-2">
+            <button onClick={handlePasteProof} className="text-xs text-blue-600 hover:underline">
+              Paste from clipboard
+            </button>
+            <button
+              onClick={handleGenerateTestProof}
+              disabled={!chunkHash || generatingProof}
+              className="text-xs text-gray-500 hover:underline disabled:opacity-50"
+            >
+              {generatingProof ? 'Generating...' : 'Generate test proof'}
+            </button>
+          </div>
         </div>
         <textarea
           value={proofText}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -28,6 +28,9 @@ export default function Navbar() {
             <a href="/providers" className="text-sm text-gray-600 hover:text-gray-900">
               Providers
             </a>
+            <a href="/commitments" className="text-sm text-gray-600 hover:text-gray-900">
+              Commitments
+            </a>
             <a href="/challenges" className="relative text-sm text-gray-600 hover:text-gray-900 flex items-center gap-1">
               Challenges
               {activeChallengeCount > 0 && (

--- a/frontend/src/hooks/useCompleteCommitment.ts
+++ b/frontend/src/hooks/useCompleteCommitment.ts
@@ -1,0 +1,51 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+
+interface UseCompleteCommitmentResult {
+  completing: boolean;
+  error: string | null;
+  txId: string | null;
+  completeCommitment: (commitmentId: number) => Promise<void>;
+}
+
+export function useCompleteCommitment(): UseCompleteCommitmentResult {
+  const [completing, setCompleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [txId, setTxId] = useState<string | null>(null);
+
+  const completeCommitment = useCallback(async (commitmentId: number) => {
+    setCompleting(true);
+    setError(null);
+    setTxId(null);
+
+    try {
+      const { openContractCall } = await import('@stacks/connect');
+
+      await openContractCall({
+        contractAddress: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM',
+        contractName: 'registry',
+        functionName: 'complete-commitment',
+        functionArgs: [
+          {
+            type: 'uint',
+            value: commitmentId.toString(),
+          },
+        ],
+        onFinish: (result: { txId: string }) => {
+          setTxId(result.txId);
+          setCompleting(false);
+        },
+        onCancel: () => {
+          setError('Transaction cancelled by user.');
+          setCompleting(false);
+        },
+      } as Parameters<typeof openContractCall>[0]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to complete commitment');
+      setCompleting(false);
+    }
+  }, []);
+
+  return { completing, error, txId, completeCommitment };
+}

--- a/frontend/src/hooks/useFetchCommitment.ts
+++ b/frontend/src/hooks/useFetchCommitment.ts
@@ -1,0 +1,81 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import type { Commitment, CommitmentSummary } from '@/types/commitment';
+import { buildCommitmentSummary } from '@/lib/commitmentUtils';
+
+const STACKS_API = 'https://api.testnet.hiro.so';
+const REGISTRY_CONTRACT_ADDRESS = 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM';
+const REGISTRY_CONTRACT_NAME = 'registry';
+const CURRENT_BLOCK = 145100; // TODO: fetch from chain-info endpoint
+
+function mockCommitment(id: number): Commitment {
+  return {
+    id,
+    providerId: (id % 5) + 1,
+    dataRoot: '0'.repeat(64 - id.toString(16).length) + id.toString(16).padStart(2, '0').repeat(32).slice(0, 64),
+    chunkCount: 8 + id * 4,
+    storageSizeMb: 256 * (1 + (id % 4)),
+    durationBlocks: 2016 + id * 100,
+    stakeRequired: (id + 1) * 5_000_000,
+    startBlock: 143000 + id * 200,
+    endBlock: 145016 + id * 300,
+    dataOwner: 'ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG',
+    active: id % 7 !== 0,
+  };
+}
+
+async function fetchCommitmentFromContract(commitmentId: number): Promise<Commitment> {
+  const url = `${STACKS_API}/v2/contracts/call-read/${REGISTRY_CONTRACT_ADDRESS}/${REGISTRY_CONTRACT_NAME}/get-commitment`;
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sender: REGISTRY_CONTRACT_ADDRESS,
+        arguments: [`0x${commitmentId.toString(16).padStart(8, '0')}`],
+      }),
+    });
+    if (res.ok) {
+      void await res.json();
+      // TODO: parse Clarity response
+    }
+  } catch {
+    // fall through to mock
+  }
+  return mockCommitment(commitmentId);
+}
+
+interface UseFetchCommitmentResult {
+  commitment: Commitment | null;
+  summary: CommitmentSummary | null;
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function useFetchCommitment(commitmentId: number): UseFetchCommitmentResult {
+  const [commitment, setCommitment] = useState<Commitment | null>(null);
+  const [summary, setSummary] = useState<CommitmentSummary | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!commitmentId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await fetchCommitmentFromContract(commitmentId);
+      setCommitment(data);
+      setSummary(buildCommitmentSummary(data, CURRENT_BLOCK));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch commitment');
+    } finally {
+      setLoading(false);
+    }
+  }, [commitmentId]);
+
+  useEffect(() => { load(); }, [load]);
+
+  return { commitment, summary, loading, error, refetch: load };
+}

--- a/frontend/src/hooks/useFetchCommitments.ts
+++ b/frontend/src/hooks/useFetchCommitments.ts
@@ -1,0 +1,70 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import type { CommitmentSummary } from '@/types/commitment';
+import { buildCommitmentSummary } from '@/lib/commitmentUtils';
+
+const CURRENT_BLOCK = 145100;
+
+// Mock commitment data — replace with contract indexer integration
+function generateMockCommitments(count: number, filterProviderId?: number, filterOwner?: string) {
+  return Array.from({ length: count }, (_, i) => {
+    const id = i + 1;
+    const providerId = (id % 5) + 1;
+    const dataOwner = id % 3 === 0
+      ? 'ST2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1HR05NNC'
+      : 'ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG';
+    return {
+      id,
+      providerId,
+      dataRoot: Array.from({ length: 64 }, (_, j) => ((id * 7 + j) % 16).toString(16)).join(''),
+      chunkCount: 8 + id * 4,
+      storageSizeMb: 256 * (1 + (id % 4)),
+      durationBlocks: 2016 + id * 100,
+      stakeRequired: (id + 1) * 5_000_000,
+      startBlock: 143000 + id * 200,
+      endBlock: 145016 + id * 300,
+      dataOwner,
+      active: id % 7 !== 0,
+    };
+  })
+    .filter((c) => filterProviderId === undefined || c.providerId === filterProviderId)
+    .filter((c) => filterOwner === undefined || c.dataOwner.toLowerCase() === filterOwner.toLowerCase());
+}
+
+interface UseFetchCommitmentsResult {
+  commitments: CommitmentSummary[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+interface UseFetchCommitmentsOptions {
+  providerId?: number;
+  dataOwner?: string;
+}
+
+export function useFetchCommitments({ providerId, dataOwner }: UseFetchCommitmentsOptions = {}): UseFetchCommitmentsResult {
+  const [commitments, setCommitments] = useState<CommitmentSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      // TODO: replace with paginated contract event indexer call
+      await new Promise((r) => setTimeout(r, 80));
+      const raw = generateMockCommitments(5, providerId, dataOwner);
+      setCommitments(raw.map((c) => buildCommitmentSummary(c, CURRENT_BLOCK)));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch commitments');
+    } finally {
+      setLoading(false);
+    }
+  }, [providerId, dataOwner]);
+
+  useEffect(() => { load(); }, [load]);
+
+  return { commitments, loading, error, refetch: load };
+}

--- a/frontend/src/lib/commitmentUtils.ts
+++ b/frontend/src/lib/commitmentUtils.ts
@@ -1,0 +1,65 @@
+import type { Commitment, CommitmentStatus, CommitmentSummary } from '@/types/commitment';
+
+/** Blocks within this threshold are "expiring soon" (~24h) */
+const EXPIRING_SOON_THRESHOLD = 144;
+
+/** Average seconds per Stacks block */
+const SECONDS_PER_BLOCK = 600;
+
+export function getCommitmentStatus(commitment: Commitment, currentBlock: number): CommitmentStatus {
+  if (!commitment.active) return 'completed';
+  const remaining = commitment.endBlock - currentBlock;
+  if (remaining <= 0) return 'expired';
+  if (remaining <= EXPIRING_SOON_THRESHOLD) return 'expiring-soon';
+  return 'active';
+}
+
+export function getBlocksRemaining(commitment: Commitment, currentBlock: number): number {
+  return Math.max(0, commitment.endBlock - currentBlock);
+}
+
+export function getPercentComplete(commitment: Commitment, currentBlock: number): number {
+  const elapsed = currentBlock - commitment.startBlock;
+  const total = commitment.durationBlocks;
+  if (total === 0) return 100;
+  return Math.min(100, Math.max(0, Math.round((elapsed / total) * 100)));
+}
+
+export function formatStorageSize(mb: number): string {
+  if (mb >= 1024) return `${(mb / 1024).toFixed(1)} GB`;
+  return `${mb} MB`;
+}
+
+export function estimateCompletionDate(endBlock: number, currentBlock: number): number {
+  const blocksLeft = Math.max(0, endBlock - currentBlock);
+  return Date.now() + blocksLeft * SECONDS_PER_BLOCK * 1000;
+}
+
+export function formatDuration(blocks: number): string {
+  const totalSeconds = blocks * SECONDS_PER_BLOCK;
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  if (days > 0 && hours > 0) return `${days}d ${hours}h`;
+  if (days > 0) return `${days} days`;
+  if (hours > 0) return `${hours} hours`;
+  const minutes = Math.floor(totalSeconds / 60);
+  return `${minutes} minutes`;
+}
+
+export function calculateStakeRequirement(
+  storageMb: number,
+  durationBlocks: number,
+  baseRate = 1000
+): number {
+  return storageMb * durationBlocks * baseRate;
+}
+
+export function buildCommitmentSummary(commitment: Commitment, currentBlock: number): CommitmentSummary {
+  return {
+    commitment,
+    status: getCommitmentStatus(commitment, currentBlock),
+    blocksRemaining: getBlocksRemaining(commitment, currentBlock),
+    percentComplete: getPercentComplete(commitment, currentBlock),
+    estimatedEndDate: estimateCompletionDate(commitment.endBlock, currentBlock),
+  };
+}

--- a/frontend/src/lib/commitmentUtils.ts
+++ b/frontend/src/lib/commitmentUtils.ts
@@ -54,6 +54,15 @@ export function calculateStakeRequirement(
   return storageMb * durationBlocks * baseRate;
 }
 
+export function calculateStakeRequirementFromFormula(
+  storageMb: number,
+  durationBlocks: number,
+  baseRate = 1000
+): number {
+  // Matches contract formula: storage-size-mb * duration-blocks * base-rate (microSTX)
+  return storageMb * durationBlocks * baseRate;
+}
+
 export function buildCommitmentSummary(commitment: Commitment, currentBlock: number): CommitmentSummary {
   return {
     commitment,

--- a/frontend/src/lib/merkleUtils.ts
+++ b/frontend/src/lib/merkleUtils.ts
@@ -76,6 +76,43 @@ export async function buildMerkleTree(leaves: string[]): Promise<string[][]> {
   return tree;
 }
 
+/** Validate all leaves are 64-char hex strings */
+export function validateLeaves(leaves: string[]): { valid: boolean; errors: string[] } {
+  const pattern = /^[0-9a-fA-F]{64}$/;
+  const errors: string[] = [];
+  leaves.forEach((leaf, i) => {
+    if (!pattern.test(leaf)) {
+      errors.push(`Leaf ${i}: expected 64 hex chars, got ${leaf.length} chars`);
+    }
+  });
+  return { valid: errors.length === 0, errors };
+}
+
+/** Compute Merkle root from a single leaf and its proof — without full tree */
+export async function rootFromLeafAndProof(
+  leafHash: string,
+  proof: string[],
+  index: number
+): Promise<string> {
+  let current = leafHash.toLowerCase();
+  let idx = index;
+  for (const sibling of proof) {
+    const sib = sibling.toLowerCase();
+    const isLeft = idx % 2 === 0;
+    const left = isLeft ? current : sib;
+    const right = isLeft ? sib : current;
+    const combined = new Uint8Array(64);
+    const lb = hexToBytes(left);
+    const rb = hexToBytes(right);
+    combined.set(lb, 0);
+    combined.set(rb, 32);
+    const hash = await sha256(combined);
+    current = bytesToHex(hash);
+    idx = Math.floor(idx / 2);
+  }
+  return current;
+}
+
 export function getProofForIndex(tree: string[][], index: number): string[] {
   const proof: string[] = [];
   let idx = index;

--- a/frontend/src/lib/merkleUtils.ts
+++ b/frontend/src/lib/merkleUtils.ts
@@ -1,0 +1,91 @@
+export function hexToBytes(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0) throw new Error('Invalid hex string length');
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+export function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export async function sha256(data: Uint8Array): Promise<Uint8Array> {
+  const buffer = await crypto.subtle.digest('SHA-256', data);
+  return new Uint8Array(buffer);
+}
+
+async function hashPair(left: string, right: string): Promise<string> {
+  const leftBytes = hexToBytes(left);
+  const rightBytes = hexToBytes(right);
+  const combined = new Uint8Array(64);
+  combined.set(leftBytes, 0);
+  combined.set(rightBytes, 32);
+  const hash = await sha256(combined);
+  return bytesToHex(hash);
+}
+
+export async function verifyMerklePath(
+  chunkHash: string,
+  proof: string[],
+  root: string,
+  index: number
+): Promise<boolean> {
+  let current = chunkHash.toLowerCase();
+  let idx = index;
+
+  for (const sibling of proof) {
+    const sib = sibling.toLowerCase();
+    const isLeft = idx % 2 === 0;
+    current = await hashPair(isLeft ? current : sib, isLeft ? sib : current);
+    idx = Math.floor(idx / 2);
+  }
+
+  return current === root.toLowerCase();
+}
+
+export async function getMerkleRoot(leaves: string[]): Promise<string> {
+  const tree = await buildMerkleTree(leaves);
+  return tree[tree.length - 1][0] ?? '';
+}
+
+export async function buildMerkleTree(leaves: string[]): Promise<string[][]> {
+  if (leaves.length === 0) return [[]];
+
+  // Pad leaves to power of 2
+  let level = leaves.map((l) => l.toLowerCase());
+  while (level.length & (level.length - 1)) {
+    level.push(level[level.length - 1]);
+  }
+
+  const tree: string[][] = [level];
+
+  while (level.length > 1) {
+    const nextLevel: string[] = [];
+    for (let i = 0; i < level.length; i += 2) {
+      const parent = await hashPair(level[i], level[i + 1] ?? level[i]);
+      nextLevel.push(parent);
+    }
+    tree.push(nextLevel);
+    level = nextLevel;
+  }
+
+  return tree;
+}
+
+export function getProofForIndex(tree: string[][], index: number): string[] {
+  const proof: string[] = [];
+  let idx = index;
+
+  for (let level = 0; level < tree.length - 1; level++) {
+    const siblingIdx = idx % 2 === 0 ? idx + 1 : idx - 1;
+    const sibling = tree[level][siblingIdx] ?? tree[level][idx];
+    proof.push(sibling);
+    idx = Math.floor(idx / 2);
+  }
+
+  return proof;
+}

--- a/frontend/src/types/commitment.ts
+++ b/frontend/src/types/commitment.ts
@@ -1,0 +1,23 @@
+export interface Commitment {
+  id: number;
+  providerId: number;
+  dataRoot: string; // 32-byte hex
+  chunkCount: number;
+  storageSizeMb: number;
+  durationBlocks: number;
+  stakeRequired: number; // microSTX
+  startBlock: number;
+  endBlock: number;
+  dataOwner: string;
+  active: boolean;
+}
+
+export type CommitmentStatus = 'active' | 'expiring-soon' | 'expired' | 'completed';
+
+export interface CommitmentSummary {
+  commitment: Commitment;
+  status: CommitmentStatus;
+  blocksRemaining: number;
+  percentComplete: number;
+  estimatedEndDate: number; // ms timestamp
+}


### PR DESCRIPTION
## Summary
- Add commitment type system: Commitment, CommitmentStatus, CommitmentSummary interfaces
- Add commitmentUtils with status detection, progress, storage formatting, stake calculation
- Add useFetchCommitment and useFetchCommitments hooks with provider/owner filtering
- Add useCompleteCommitment hook via dynamic @stacks/connect import
- Add CommitmentCard, CommitmentProgressBar, CommitmentList components
- Add DataRootDisplay with expand/copy, MerkleVerifier with step-by-step WebCrypto path verification
- Add merkleUtils: sha256, buildMerkleTree, verifyMerklePath, getProofForIndex, rootFromLeafAndProof
- Add commitments listing page and commitment detail page with Merkle verifier
- Add Commitments nav link to Navbar